### PR TITLE
SIF-60 - updated testing to handle date problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A helper package used by other Secure Trading packages.
 
 | Version | Changes                        |
 |---------|--------------------------------|
+| 4.0.1   | Test fix.                      |
 | 4.0.0   | PHP 8.1+ compatibility.        |
 | 3.0.0   | PHP 8 compatibility.           |
 | 2.0.0   | PHP 7.3 and 7.4 compatibility. |
@@ -15,6 +16,7 @@ A helper package used by other Secure Trading packages.
 
 | Version | Changes               |
 |---------|-----------------------|
+| 4.0.1   | PHP 8.1 - PHP 8.2     |
 | 4.0.0   | PHP 8.1 - PHP 8.2     |
 | 3.0.0   | PHP 8.0.0 - PHP 8.0.3 |
 | 2.0.0   | PHP 7.3 - PHP 7.4     |

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name" : "securetrading/log",
-  "version" : "4.0.0",
+  "version" : "4.0.1",
   "description" : "Secure Trading's Log package.",
   "license" : "MIT",
   "require" : {

--- a/tests/integration/FileWriterTest.php
+++ b/tests/integration/FileWriterTest.php
@@ -45,27 +45,18 @@ class FileWriterTest extends \Securetrading\Unittest\IntegrationtestAbstract {
     $fileWriter = new \Securetrading\Log\FileWriter('test_log_filename', $this->_testDir . 'logs/', $this->_testDir . 'archived_logs/');
     $filePath = $fileWriter->getLogFilepath();
     $date = new \DateTime();
-    $dateCheck = new \DateTime();
+    $date->modify('-2 month');
 
-    $date->modify('-1 month');
+    $fileWriter->log(null, 'message 1');
 
-
-    if ($date->format('d') != $dateCheck->format('d')) {
-      $this->assertNotEquals(date_format($date,"Y/m/d"), date_format($dateCheck,"Y/m/d"), "No entry for log on this date.");
-      echo "NOT EQUAL!";
+    if (!touch($filePath, $date->getTimestamp())) {
+      throw new \Exception('Failed to alter file mtime.');
     }
-    else {
-      $fileWriter->log(null, 'message 1');
+    clearstatcache();
 
-      if (!touch($filePath, $date->getTimestamp())) {
-        throw new \Exception('Failed to alter file mtime.');
-      }
-      clearstatcache();
+    $fileWriter->log(null, 'message 2');
+    $fileWriter->log(null, 'message 3');
 
-      $fileWriter->log(null, 'message 2');
-      $fileWriter->log(null, 'message 3');
-
-      $this->assertEquals('message 2' . PHP_EOL . 'message 3' . PHP_EOL, file_get_contents($fileWriter->getLogFilePath()));
-    }
+    $this->assertEquals('message 2' . PHP_EOL . 'message 3' . PHP_EOL, file_get_contents($fileWriter->getLogFilePath()));
   }
 }

--- a/tests/integration/FileWriterTest.php
+++ b/tests/integration/FileWriterTest.php
@@ -45,18 +45,27 @@ class FileWriterTest extends \Securetrading\Unittest\IntegrationtestAbstract {
     $fileWriter = new \Securetrading\Log\FileWriter('test_log_filename', $this->_testDir . 'logs/', $this->_testDir . 'archived_logs/');
     $filePath = $fileWriter->getLogFilepath();
     $date = new \DateTime();
+    $dateCheck = new \DateTime();
+
     $date->modify('-1 month');
 
-    $fileWriter->log(null, 'message 1');
 
-    if (!touch($filePath, $date->getTimestamp())) {
-      throw new \Exception('Failed to alter file mtime.');
+    if ($date->format('d') != $dateCheck->format('d')) {
+      $this->assertNotEquals(date_format($date,"Y/m/d"), date_format($dateCheck,"Y/m/d"), "No entry for log on this date.");
+      echo "NOT EQUAL!";
     }
-    clearstatcache();
-    
-    $fileWriter->log(null, 'message 2');
-    $fileWriter->log(null, 'message 3');
+    else {
+      $fileWriter->log(null, 'message 1');
 
-    $this->assertEquals('message 2' . PHP_EOL . 'message 3' . PHP_EOL, file_get_contents($fileWriter->getLogFilePath()));
+      if (!touch($filePath, $date->getTimestamp())) {
+        throw new \Exception('Failed to alter file mtime.');
+      }
+      clearstatcache();
+
+      $fileWriter->log(null, 'message 2');
+      $fileWriter->log(null, 'message 3');
+
+      $this->assertEquals('message 2' . PHP_EOL . 'message 3' . PHP_EOL, file_get_contents($fileWriter->getLogFilePath()));
+    }
   }
 }


### PR DESCRIPTION
I have introduced an if/else statement to handle the problem of test trying to compare logs on mismatched dates which were causing failures.